### PR TITLE
Losen setup restrictions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,4 @@ setup(name='PythonBotnet',
       ],
       author='Martin Řepa',
       author_email='repa.martin@hotmail.com',
-      python_requires='>3.7.*',
 )


### PR DESCRIPTION
Remove python_requires='>3.7.*'. There's no need for such restriction right now.